### PR TITLE
Fix/#23 책 복수 등록 시 중복되는 책에 대한 로직 수정

### DIFF
--- a/src/main/java/bricktoon/server/book/repository/BookRepository.java
+++ b/src/main/java/bricktoon/server/book/repository/BookRepository.java
@@ -5,10 +5,12 @@ import bricktoon.server.user.domain.Place;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BookRepository extends JpaRepository<Book, Long> {
     List<Book> findAllByNameContainsAndPlaceOrderByNameAsc(String name, Place place);
     List<Book> findAllByGenreAndPlaceOrderByNameAsc(String genre, Place place);
     List<Book> findAllByPlaceOrderByNameAsc(Place place);
     Boolean existsByName(String name);
+    Optional<Book> findByName(String name);
 }

--- a/src/main/java/bricktoon/server/book/service/BookService.java
+++ b/src/main/java/bricktoon/server/book/service/BookService.java
@@ -76,8 +76,16 @@ public class BookService {
                 completeRow = (long) row.getRowNum();
             completeRow++;
 
-            if (bookRepository.existsByName(book.getName()))
+            if (bookRepository.existsByName(book.getName())) {
+                bookRepository.findByName(book.getName()).get().update(
+                        row.getCell(0).getStringCellValue(),
+                        row.getCell(1).getStringCellValue(),
+                        row.getCell(2).getStringCellValue(),
+                        (int) row.getCell(4).getNumericCellValue(),
+                        user.getPlace()
+                );
                 continue;
+            }
             bookList.add(book);
         }
 


### PR DESCRIPTION
## Summary 📌
- 책 복수 등록 시 중복되는 책에 대한 로직을 덮어쓰지 않음 >> 덮어씀 으로 수정
## Describe your changes 📝
- 서비스 및 쿼리 수정
## Check list ✅
- [x] I write PR according to the form
- [x] All tests are passed
- [x] Program works normally
- [x] I set proper PR labels
- [x] I remove any redundant codes

## Opinions 🗣️

## Issue numbers and link 🚪
Closes #23 